### PR TITLE
fix: allow CDK versions other than 2.79

### DIFF
--- a/construct/package.json
+++ b/construct/package.json
@@ -13,8 +13,8 @@
   "packageManager": "pnpm@8.3.1",
   "dependencies": {
     "@apimda/npm-layer-version": "^1.0.0",
-    "@aws-cdk/aws-apigatewayv2-alpha": "2.79.0-alpha.0",
-    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.79.0-alpha.0",
+    "@aws-cdk/aws-apigatewayv2-alpha": "^2.79.0-alpha.0",
+    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.79.0-alpha.0",
     "aws-cdk-lib": "^2.79.0",
     "constructs": "^10.2.19"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       '@aws-cdk/aws-apigatewayv2-alpha':
-        specifier: 2.79.0-alpha.0
+        specifier: ^2.79.0-alpha.0
         version: 2.79.0-alpha.0(aws-cdk-lib@2.79.0)(constructs@10.2.19)
       '@aws-cdk/aws-apigatewayv2-integrations-alpha':
-        specifier: 2.79.0-alpha.0
+        specifier: ^2.79.0-alpha.0
         version: 2.79.0-alpha.0(@aws-cdk/aws-apigatewayv2-alpha@2.79.0-alpha.0)(aws-cdk-lib@2.79.0)(constructs@10.2.19)
       aws-cdk-lib:
         specifier: ^2.79.0


### PR DESCRIPTION
Currently the @aws-cdk/aws-apigatewayv2-* require exactly version 2.79.0-alpha.  This uses ^ to allow versions from 2.79.0 and less than 3.0.0, which is probably what we want.

(BTW, not 100% sure this works - when linking into test repository, for some reason the entire project stops working - something to do with constructs library.)